### PR TITLE
fix: file tree rendering on GitHub markdown renderer

### DIFF
--- a/templates/ja/prompts/sdd-steering.md
+++ b/templates/ja/prompts/sdd-steering.md
@@ -111,7 +111,7 @@
 ### 3. Project Structure (`.sdd/steering/structure.md`)
 
 #### 新規作成の場合：
-```markdown
+````markdown
 # Project Structure
 
 ## ルートディレクトリ構成
@@ -132,7 +132,7 @@
 ## 主要な設計原則
 - [原則1]：[説明]
 - [原則2]：[説明]
-```
+````
 
 #### 更新の場合：
 構造的な変更のみ反映：


### PR DESCRIPTION
I've increased the number of backticks to ensure markdown-in-markdown renders correctly on GitHub.
I believe this will also positively impact the Codex from a structural perspective.

Thank you for developing this excellent tool 🫶 


---

## before
<img width="1042" height="485" alt="image" src="https://github.com/user-attachments/assets/771778d3-466a-40e1-9310-f0b15dbfe6f4" />

## after
<img width="1038" height="533" alt="image" src="https://github.com/user-attachments/assets/362b33ba-1520-400e-a234-2f7500cca1b9" />
